### PR TITLE
FormValidator fixes

### DIFF
--- a/web/assets/default/scripts/Components/FormValidator.js
+++ b/web/assets/default/scripts/Components/FormValidator.js
@@ -55,7 +55,7 @@
             }
 
             // Validate form on submit
-            submitButton.addEventListener('click', function(e){
+            submitButton.addEventListener('click', function(fields, $el, e){
                 var formIsValid = true;
 
                 // Loop each field
@@ -71,7 +71,7 @@
                     e.preventDefault();
                     $el.querySelector('.-invalid').querySelector('input, textarea, select').focus();
                 }
-            });
+            }.bind(this, fields, $el));
         }
     }
 }());

--- a/web/assets/default/scripts/Components/FormValidator.js
+++ b/web/assets/default/scripts/Components/FormValidator.js
@@ -2,19 +2,30 @@
 ;(function(){
     var component = document.querySelectorAll('[data-component="FormValidator"]')
 
+    var isHtml5FormValidatorLoaded = false;
+    var isPasswordStrengthCalculatorScriptLoaded = false;
+
     // Dependancy
     var script = document.createElement('script');
-    script.src = './assets/default/scripts/HTML5FormValidator.js';
+    script.src = '/assets/default/scripts/HTML5FormValidator.js';
     script.onload = function () {
-        init();
+        isHtml5FormValidatorLoaded = true;
+
+        if (isPasswordStrengthCalculatorScriptLoaded) {
+            init();
+        }
     };
 
     document.head.appendChild(script);
 
     var script = document.createElement('script');
-    script.src = './assets/default/scripts/PasswordStrengthCalculator.js';
+    script.src = '/assets/default/scripts/PasswordStrengthCalculator.js';
     script.onload = function () {
-        init();
+        isPasswordStrengthCalculatorScriptLoaded = true;
+
+        if (isHtml5FormValidatorLoaded) {
+            init();
+        }
     };
 
     document.head.appendChild(script);
@@ -22,22 +33,22 @@
     function init(){
         for (var i = 0; i < component.length; i++) {
             var $el = component[i];
-            var fields = document.querySelectorAll('input, textarea, select');
+            var fields = $el.querySelectorAll('input, textarea, select');
             var submitButton = $el.querySelector('[type=submit]');
 
-            for (var i = 0; i < fields.length; i++) {
-                if (fields[i].type === "password" && fields[i].required === true) {
-                    fields[i].addEventListener('keyup', function(){
+            for (var j = 0; j < fields.length; j++) {
+                if (fields[j].type === "password" && fields[j].required === true) {
+                    fields[j].addEventListener('keyup', function(){
                         // Validate this field
                         // and pass translations for validator message
                         var validate = new HTML5FormValidator(this, {messages: formvalidator_translations, showSuccess: true});
                     });
-                } else if (fields[i].type === "password" && fields[i].required === false) {
-                    fields[i].addEventListener('keyup', function(){
+                } else if (fields[j].type === "password" && fields[j].required === false) {
+                    fields[j].addEventListener('keyup', function(){
                         var validate = new PasswordStrengthCalculator(this, {passwordTier: password_strength_translations});
                     });
                 } else {
-                    fields[i].addEventListener('blur', function(){
+                    fields[j].addEventListener('blur', function(){
                         var validate = new HTML5FormValidator(this, {messages: formvalidator_translations, showSuccess: true});
                     });
                 }
@@ -48,9 +59,9 @@
                 var formIsValid = true;
 
                 // Loop each field
-                for (var i = 0; i < fields.length; i++) {
+                for (var j = 0; j < fields.length; j++) {
                     // Pass translations for validator message
-                    var field = new HTML5FormValidator(fields[i], {messages: formvalidator_translations, showSuccess: true});
+                    var field = new HTML5FormValidator(fields[j], {messages: formvalidator_translations, showSuccess: true});
                     if(!field.isValid) {
                         formIsValid = false;
                     }
@@ -58,7 +69,7 @@
 
                 if (!formIsValid) {
                     e.preventDefault();
-                    document.querySelector('.-invalid').querySelector('input, textarea, select').focus();
+                    $el.querySelector('.-invalid').querySelector('input, textarea, select').focus();
                 }
             });
         }


### PR DESCRIPTION
This fixes the following issues with the `FormValidator` component:

* There was no guarantee the two dependencies (scripts) were loaded before `init` was called. Only one of them was guaranteed to be loaded.
* Loop variables were being shadowed: `i` was being used in the outer loop as well as the inner loop.
* All fields on the page were being fetched instead of just the fields inside the form. This causes unrelated forms to validate each other's fields.
* Because the loop variables were not bound to the `click` event via the `bind` method, the value of `fields` and other loop variables was always the value they were during the last iteration.