### PR TITLE
Fix optional password fields still being validated for password correctness

### DIFF
--- a/web/assets/default/scripts/HTML5FormValidator.js
+++ b/web/assets/default/scripts/HTML5FormValidator.js
@@ -141,7 +141,7 @@
         }
 
         // Required
-        if (element.matches('select[required]') && this.validate(element, 'requiredSelect')) {
+        if (element.matches('select[required]:enabled') && this.validate(element, 'requiredSelect')) {
             return 'requiredSelect';
         }
 

--- a/web/assets/default/scripts/HTML5FormValidator.js
+++ b/web/assets/default/scripts/HTML5FormValidator.js
@@ -141,7 +141,7 @@
         }
 
         // Required
-        if (element.matches('select[required]:enabled') && this.validate(element, 'requiredSelect')) {
+        if (element.matches('select[required]') && this.validate(element, 'requiredSelect')) {
             return 'requiredSelect';
         }
 
@@ -295,6 +295,10 @@
             return checked;
         },
         password: function ( el ) {
+            if (!el.required && el.value.length == 0) {
+                return true;
+            }
+
             var regExLowerCase = /[a-z]/;
             var regExUpperCase = /[A-Z]/;
             var regExNumber    = /\d/;


### PR DESCRIPTION
When a password field was not required, the validator was still complaining about the input not being a decent password.