### PR TITLE
Fix min and max form field validation not working

### DIFF
--- a/resources/views/iframe.html.twig
+++ b/resources/views/iframe.html.twig
@@ -50,8 +50,8 @@
         maxlength:             "Dit veld mag maximaal %1$s karakters bevatten",
         email:                 "Dit is geen geldig e-mailadres",
         tel:                   "Dit is geen geldig telefoonnummer (bv.: +3232987651)",
-        min:                   "Het getal moet %1 of groter zijn",
-        max:                   "Het getal moet %1 of kleiner zijn"
+        min:                   "Het getal moet %1$s of groter zijn",
+        max:                   "Het getal moet %1$s of kleiner zijn"
     };
 
     var password_strength_translations = {

--- a/web/assets/default/scripts/HTML5FormValidator.js
+++ b/web/assets/default/scripts/HTML5FormValidator.js
@@ -186,12 +186,12 @@
         }
 
         // min
-        if (element.matches('input[type=min]:enabled') && this.validate(element, 'min')) {
+        if (element.matches('input[min]:enabled') && this.validate(element, 'min')) {
             return 'min';
         }
 
         // max
-        if (element.matches('input[type=max]:enabled') && this.validate(element, 'max')) {
+        if (element.matches('input[max]:enabled') && this.validate(element, 'max')) {
             return 'max';
         }
 
@@ -375,7 +375,7 @@
         errorElement = parent.querySelector('.' + this.options.errorMessageClass);
 
         // set attribute value on placeholder (mostly used for min and max values)
-        if (message.search('%1') != -1) {
+        if (message.indexOf('%1$s') != -1) {
             message = message.replace('%1$s', element.getAttribute(type));
         }
 


### PR DESCRIPTION
Min and max currently search for an `input type="min"` or `input type="max"`, but `min` and `max` are both attributes of an `input type="number"`.

I've also updated the error message placeholders to match those of minlength and maxlength (it is also the format used by vsprint in PHP).