### PR TITLE
Minify files on copy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -133,7 +133,6 @@ gulp.task('copy', ['set:theme'], function() {
         .pipe(minify({
             noSource: true,
             ext:{
-                // src:'-debug.js',
                 src: '.js',
                 min:'.js'
             }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var gulp = require('gulp');
 var sass = require('gulp-sass');
 var minify = require('gulp-minify');
 var rename = require('gulp-rename');
+var minify = require('gulp-minify');
 var sassGlob = require('gulp-sass-glob'); // globbing for gulp-sass
 var iconfont = require('gulp-iconfont'); // To generate an icon-font
 var iconfontCss = require('gulp-iconfont-css'); // To generate a css file for the icon-font
@@ -129,6 +130,14 @@ gulp.task('copy', ['set:theme'], function() {
 
     // Scripts
     gulp.src(cwd + 'scripts/**/*.js')
+        .pipe(minify({
+            noSource: true,
+            ext:{
+                // src:'-debug.js',
+                src: '.js',
+                min:'.js'
+            }
+        }))
         .pipe(gulp.dest(dest + 'scripts/'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,7 @@ gulp.task('copy', ['set:theme'], function() {
     gulp.src(cwd + 'scripts/**/*.js')
         .pipe(minify({
             noSource: true,
-            ext:{
+            ext: {
                 src: '.js',
                 min:'.js'
             }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-sass-glob": "^1.0.8",
     "gulp-sourcemaps": "^2.1.1",
     "gulp-util": "^3.0.7",
+    "gulp-minify": "^2.1.0",
     "jsonlylightbox": "^0.5.5",
     "modernizr": "^3.3.1",
     "normalize.css": "git://github.com/necolas/normalize.css.git",


### PR DESCRIPTION
By only minifying on copy, it keeps the original files intact for editing and only minifies the files that will be served.

An alternative is to minify the files in the same folder and give them another suffix such as `.min.js`. In that case, the `.js` variants should probably not be copied anymore as they are useless when serving.