### PR TITLE
Lock gulp-minify to ES5-compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-sass-glob": "^1.0.8",
     "gulp-sourcemaps": "^2.1.1",
     "gulp-util": "^3.0.7",
-    "gulp-minify": "^2.1.0",
+    "gulp-minify": "es5",
     "jsonlylightbox": "^0.5.5",
     "modernizr": "^3.3.1",
     "normalize.css": "git://github.com/necolas/normalize.css.git",


### PR DESCRIPTION
This actually did work for minification locally, but there may be an incorrect uglify version used in some environments.

See also https://github.com/hustxiaoc/gulp-minify/issues/27